### PR TITLE
Quay integration

### DIFF
--- a/.github/workflows/quay.yml
+++ b/.github/workflows/quay.yml
@@ -1,0 +1,29 @@
+name: Quay
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+"
+  workflow_dispatch:
+
+env:
+  REGISTRY: quay.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Registry login
+        run: echo "${{ secrets.QUAY_TOKEN }}" | podman login ${REGISTRY} -u ${{ secrets.QUAY_USER }} --password-stdin
+
+      - name: Build and Push images
+        run: |
+          ORG=${GITHUB_REPOSITORY%/*}
+          TAG=$(git tag --points-at HEAD)
+          VERSION=${TAG/v/}
+          make all ORG=${ORG} VERSION=${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 # Current Operator version
-VERSION ?= 0.2.5
-REGISTRY ?= quay.io
-ORG ?= rh-nfv-int
+VERSION         := 0.2.5
+TAG             := v$(VERSION)
+REGISTRY        ?= quay.io
+ORG             ?= rh-nfv-int
 DEFAULT_CHANNEL ?= alpha
-
-CLUSTER_CLI ?= oc
+CONTAINER_CLI   ?= podman
+CLUSTER_CLI     ?= oc
+OPERATOR_NAME   := trex-operator
 
 # Default bundle image tag
-BUNDLE_IMG ?= $(REGISTRY)/$(ORG)/trex-operator-bundle:v$(VERSION)
+BUNDLE_IMG ?= $(REGISTRY)/$(ORG)/$(OPERATOR_NAME)-bundle:$(TAG)
 # Options for 'bundle-build'
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
@@ -18,9 +20,15 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
-IMG ?= $(REGISTRY)/$(ORG)/trex-operator:v$(VERSION)
+IMG ?= $(REGISTRY)/$(ORG)/$(OPERATOR_NAME):$(TAG)
 
-all: docker-build docker-push
+all: operator-all bundle-all
+
+# Operator build and push
+operator-all: operator-build operator-push
+
+# Bundle build and push
+bundle-all: bundle-build bundle-push
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: ansible-operator
@@ -47,13 +55,13 @@ deploy: kustomize
 undeploy: kustomize
 	$(KUSTOMIZE) build config/default | ${CLUSTER_CLI} delete -f -
 
-# Build the docker image
-docker-build:
-	podman build . -t ${IMG}
+# Build the operator image
+operator-build:
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build . -t ${IMG}
 
-# Push the docker image
-docker-push: docker-build
-	podman push ${IMG}
+# Push the operator image
+operator-push:
+	${CONTAINER_CLI} push ${IMG}
 
 PATH  := $(PATH):$(PWD)/bin
 SHELL := env PATH=$(PATH) /bin/sh
@@ -79,6 +87,23 @@ KUSTOMIZE=$(shell which kustomize)
 endif
 endif
 
+# Installs operator-sdk if is not available
+.PHONY: operator-sdk
+OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
+operator-sdk:
+ifeq (,$(wildcard $(OPERATOR_SDK)))
+ifeq (,$(shell which operator-sdk 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(OPERATOR_SDK)) ;\
+	curl -sLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.7.2/operator-sdk_$(OS)_$(ARCH) ; \
+	chmod u+x $(OPERATOR_SDK) ; \
+	}
+else
+OPERATOR_SDK=$(shell which operator-sdk)
+endif
+endif
+
 # Download ansible-operator locally if necessary, preferring the $(pwd)/bin path over global if both exist.
 .PHONY: ansible-operator
 ANSIBLE_OPERATOR = $(shell pwd)/bin/ansible-operator
@@ -98,14 +123,25 @@ endif
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle
-bundle: kustomize
-	operator-sdk generate kustomize manifests -q
+bundle: kustomize operator-sdk
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	operator-sdk bundle validate ./bundle
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	DIGEST=$$(skopeo inspect docker://$(IMG) | jq -r '.Digest') && sed -i -e 's/\(\s*image: .*\):v'$(VERSION)'/\1@'$${DIGEST}'/' bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+	sed -i -e '/^# Copy.*/i LABEL com.redhat.openshift.versions="v4.6"\nLABEL com.redhat.delivery.backport=false\nLABEL com.redhat.delivery.operator.bundle=true' bundle.Dockerfile
+	cat relatedImages.yaml >> bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+	$(OPERATOR_SDK) bundle validate ./bundle
 
-# Build the bundle image.
+# Build the bundle image, using local bundle image name
 .PHONY: bundle-build
-bundle-build:
-	podman build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
-	podman push $(BUNDLE_IMG)
+bundle-build: bundle
+	BUILDAH_FORMAT=docker ${CONTAINER_CLI} build -f bundle.Dockerfile \
+		-t bundle .
+
+# Tag local bundle image with our registry BUNDLE_IMG
+bundle-tag:
+	${CONTAINER_CLI} tag bundle $(BUNDLE_IMG)
+
+# Push the BUNDLE_IMG
+bundle-push: bundle-tag
+	${CONTAINER_CLI} push $(BUNDLE_IMG)

--- a/relatedImages.yaml
+++ b/relatedImages.yaml
@@ -1,0 +1,5 @@
+  relatedImages:
+    - name: trex-container-server
+      image: "quay.io/rh-nfv-int/trex-container-server@sha256:57ab22022c81d6556c5c11acda05e823ebfabb3b539242519868c7a5b8213e48"
+    - name: trex-container-app
+      image: "quay.io/rh-nfv-int/trex-container-app@sha256:b78cf57524d298f08a3ad480417b1d150eec70a31d36ad3bb4fc796534d8c7f4"

--- a/roles/app/defaults/main.yml
+++ b/roles/app/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
-version: ''
-registry: quay.io
-org: rh-nfv-int
+image_app: "quay.io/rh-nfv-int/trex-container-app@sha256:b78cf57524d298f08a3ad480417b1d150eec70a31d36ad3bb4fc796534d8c7f4" # v0.2.2
 image_pull_policy: Always
 command: ["trex-wrapper"]
 environments: {}

--- a/roles/app/tasks/job-check.yml
+++ b/roles/app/tasks/job-check.yml
@@ -4,22 +4,22 @@
     kind: Job
     api_version: batch/v1
     label_selectors:
-    - example-cnf-type=pkt-gen-app
+      - example-cnf-type=pkt-gen-app
     field_selectors:
-    - status.successful!=1
+      - status.successful!=1
   register: jobs_running
+
 - name: set default active job fact
   set_fact:
     active_jobs: 0
+
 - name: find active jobs
   set_fact:
     active_jobs: "{{ active_jobs + 1 }}"
   loop: "{{ jobs_running.resources }}"
   when:
     - "'failed' not in item.status or item.status.failed != 1"
-- name: set image path
-  set_fact:
-    image_app: "{{ registry }}/{{ org }}/trex-container-app:{{ version }}"
+
 - name: create trexapp job
   k8s:
     state: present

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
-version: ''
-registry: quay.io
-org: rh-nfv-int
+image_server: "quay.io/rh-nfv-int/trex-container-server@sha256:57ab22022c81d6556c5c11acda05e823ebfabb3b539242519868c7a5b8213e48" # v0.2.2
+image_app: "quay.io/rh-nfv-int/trex-container-app@sha256:b78cf57524d298f08a3ad480417b1d150eec70a31d36ad3bb4fc796534d8c7f4" # v0.2.2
 image_pull_policy: IfNotPresent
 privileged: false
 command: ["trex-wrapper"]

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -1,14 +1,8 @@
 ---
-- name: fail if version is not provided
-  fail:
-    msg: "application 'version' in CR is required"
-  when: "version|length == 0"
-
-- set_fact:
+- name: Set default newtork facts
+  set_fact:
     network_resources: {}
     network_name_list: []
-    image_server: "{{ registry }}/{{ org }}/trex-container-server:{{ version }}"
-    image_app: "{{ registry }}/{{ org }}/trex-container-app:{{ version }}"
 
 - name: Check if networks parameter is empty
   fail:
@@ -38,11 +32,11 @@
         selector:
           example-cnf-type: pkt-gen
         ports:
-        - port: 4500
-          protocol: TCP
-          targetPort: 4500
-          name: async
-        - port: 4501
-          protocol: TCP
-          targetPort: 4501
-          name: sync
+          - port: 4500
+            protocol: TCP
+            targetPort: 4500
+            name: async
+          - port: 4501
+            protocol: TCP
+            targetPort: 4501
+            name: sync


### PR DESCRIPTION
This is almost the same as was proposed in [testpmd-operator](https://github.com/rh-nfv-int/testpmd-operator/pull/7). This creates a workflow to build the operator and the bundle on a tagged release. The result artifacts are published in quay.io

- Extends `Makefile` to build/push operator and bundle, and install operator-sdk. Supporting SHA2 digest
- Makes use of digest in the images used by the operator, is still possible to use other images by specifying the full URL
- Adds `relatedImages` to support SHA2 digest (allowing disconnected)

I've tested this flow in my repo and my registry to store the images generated. The output of the [GH Action is here ](https://github.com/tonyskapunk/trex-operator/actions/runs/961508793)

---

cc: @betoredhat, @krsacme 