### PR TITLE
Make easy to update kustomize and operator-sdk ver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 # Current Operator version
-VERSION         := 0.2.9
-TAG             := v$(VERSION)
-REGISTRY        ?= quay.io
-ORG             ?= rh-nfv-int
-DEFAULT_CHANNEL ?= alpha
-CONTAINER_CLI   ?= podman
-CLUSTER_CLI     ?= oc
-OPERATOR_NAME   := trex-operator
+VERSION          := 0.2.9
+TAG              := v$(VERSION)
+REGISTRY         ?= quay.io
+ORG              ?= rh-nfv-int
+DEFAULT_CHANNEL  ?= alpha
+CONTAINER_CLI    ?= podman
+CLUSTER_CLI      ?= oc
+OPERATOR_NAME    := trex-operator
+OPERATOR_SDK_VER := 1.7.2
+KUSTOMIZE_VER    := 3.5.4
 
 # Default bundle image tag
 BUNDLE_IMG ?= $(REGISTRY)/$(ORG)/$(OPERATOR_NAME)-bundle:$(TAG)
@@ -70,38 +72,31 @@ ARCH  = $(shell uname -m | sed 's/x86_64/amd64/')
 OSOPER   = $(shell uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/apple-darwin/' | sed 's/linux/linux-gnu/')
 ARCHOPER = $(shell uname -m )
 
-# Download kustomize locally if necessary, preferring the $(pwd)/bin path over global if both exist.
+# Download kustomize locally if necessary in $(pwd)/bin
 .PHONY: kustomize
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize:
 ifeq (,$(wildcard $(KUSTOMIZE)))
-ifeq (,$(shell which kustomize 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(KUSTOMIZE)) ;\
-	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.5.4/kustomize_v3.5.4_$(OS)_$(ARCH).tar.gz | \
+	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v$(KUSTOMIZE_VER)/kustomize_v$(KUSTOMIZE_VER)_$(OS)_$(ARCH).tar.gz | \
 	tar xzf - -C bin/ ;\
 	}
-else
-KUSTOMIZE=$(shell which kustomize)
-endif
 endif
 
-# Installs operator-sdk if is not available
+# Installs operator-sdk if is not available in $(pwd)/bin
 .PHONY: operator-sdk
 OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
 operator-sdk:
 ifeq (,$(wildcard $(OPERATOR_SDK)))
-ifeq (,$(shell which operator-sdk 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	curl -sLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.7.2/operator-sdk_$(OS)_$(ARCH) ; \
+	curl -sLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v$(OPERATOR_SDK_VER)/operator-sdk_$(OS)_$(ARCH) ; \
 	chmod u+x $(OPERATOR_SDK) ; \
 	}
 else
-OPERATOR_SDK=$(shell which operator-sdk)
-endif
 endif
 
 # Download ansible-operator locally if necessary, preferring the $(pwd)/bin path over global if both exist.


### PR DESCRIPTION
Only used the installed operator-sdk or kustomize through makefile Remains using the current kustomize and operator-sdk versions